### PR TITLE
Remove unneeded streams from Theme YAML

### DIFF
--- a/library.yaml
+++ b/library.yaml
@@ -12,10 +12,3 @@ searchPlaceHolder: 'Search the Library'
 blogContinueText: 'Continue Reading...'
 daringLinkIcon: 'exclamation-circle'
 animateOnPageLoad: false
-
-streams:
-  scheme:
-    theme:
-      type: ReadOnlyStream
-      paths:
-        - user/themes/library


### PR DESCRIPTION
These lines were in Antimatter and other themes, but they are useless now and break multisite
